### PR TITLE
Support for ipmievd.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,16 +4,26 @@
 #
 # include ipmi
 #
+# class { 'ipmi':
+#   start_ipmievd => true,
+# }
+#
 # === Authors
 #
 # Joshua Hoblitt <jhoblitt@cpan.org>
+# Mike Arnold <mike@razorsedge.org>
 #
 # === Copyright
 #
 # Copyright (C) 2013 Joshua Hoblitt
+# Copyright (C) 2013 Mike Arnold, unless otherwise noted.
 #
-class ipmi inherits ipmi::params {
+class ipmi (
+  $start_ipmievd = false,
+) inherits ipmi::params {
   class { 'ipmi::install': } ->
-  class { 'ipmi::service': } ->
+  class { 'ipmi::service':
+    start_ipmievd => $start_ipmievd,
+  } ->
   Class['Ipmi']
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,12 +5,30 @@
 # === Authors
 #
 # Joshua Hoblitt <jhoblitt@cpan.org>
+# Mike Arnold <mike@razorsedge.org>
 #
 # === Copyright
 #
 # Copyright (C) 2013 Joshua Hoblitt
+# Copyright (C) 2013 Mike Arnold, unless otherwise noted.
 #
-class ipmi::service {
+class ipmi::service (
+  $start_ipmievd = false,
+) {
+  case $start_ipmievd {
+    /(true)/: {
+      $ipmievd_ensure = 'running'
+      $ipmievd_enable = true
+    }
+    /(false)/: {
+      $ipmievd_ensure = 'stopped'
+      $ipmievd_enable = false
+    }
+    default: {
+      fail('start_ipmievd parameter must be true or false')
+    }
+  }
+
   service{ 'ipmi':
     ensure      => running,
     hasstatus   => true,
@@ -19,9 +37,9 @@ class ipmi::service {
   }
 
   service{ 'ipmievd':
-    ensure      => running,
+    ensure      => $ipmievd_ensure,
     hasrestart  => true,
     hasstatus   => true,
-    enable      => true,
+    enable      => $ipmievd_enable,
   }
 }

--- a/spec/classes/ipmi_service_spec.rb
+++ b/spec/classes/ipmi_service_spec.rb
@@ -13,11 +13,26 @@ describe 'ipmi::service', :type => :class do
 
   it do
     should contain_service('ipmievd').with({
-      :ensure => 'running',
+      :ensure => 'stopped',
       :hasstatus => 'true',
       :hasrestart => 'true',
-      :enable => 'true',
+      :enable => 'false',
     })
   end
 
+  describe 'with start_ipmievd => true' do
+    let :params do
+      {
+        :start_ipmievd => 'true',
+      }
+    end
+    it do
+      should contain_service('ipmievd').with({
+        :ensure => 'running',
+        :hasstatus => 'true',
+        :hasrestart => 'true',
+        :enable => 'true',
+      })
+    end
+  end
 end


### PR DESCRIPTION
This initial PR adds basic ipmievd server support and defaults to running the service.  I can provide another commit that adds a class parameter to selectively turn it on.

This tracks issue #1.
