### PR TITLE
remove usage of $::lsbmajdistrelease fact

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@
 class ipmi::params {
   case $::osfamily {
     'redhat': {
-      case $::lsbmajdistrelease {
+      case $::operatingsystemmajrelease {
         5: {
           # el5.x
           $ipmi_package = ['OpenIPMI', 'OpenIPMI-tools']
@@ -23,7 +23,7 @@ class ipmi::params {
           $ipmi_package = ['OpenIPMI', 'ipmitool']
         }
         default: {
-          fail("Module ${module_name} is not supported on lsbmajdistrelease ${::lsbmajdistrelease}")
+          fail("Module ${module_name} is not supported on operatingsystemmajrelease ${::operatingsystemmajrelease}")
         }
       }
     }

--- a/spec/classes/ipmi_install_spec.rb
+++ b/spec/classes/ipmi_install_spec.rb
@@ -13,7 +13,7 @@ describe 'ipmi::install', :type => :class do
     end
 
     describe 'el5.x' do
-      before { facts[:lsbmajdistrelease] = '5' }
+      before { facts[:operatingsystemmajrelease] = '5' }
   
       it { should include_class('ipmi::install') }
       it { should contain_package('OpenIPMI').with_ensure('present') }
@@ -21,7 +21,7 @@ describe 'ipmi::install', :type => :class do
     end
 
     describe 'el6.x' do
-      before { facts[:lsbmajdistrelease] = '6' }
+      before { facts[:operatingsystemmajrelease] = '6' }
   
       it { should include_class('ipmi::install') }
       it { should contain_package('OpenIPMI').with_ensure('present') }

--- a/spec/classes/ipmi_params_spec.rb
+++ b/spec/classes/ipmi_params_spec.rb
@@ -5,23 +5,23 @@ describe 'ipmi::params', :type => :class do
     let(:facts) {{ :osfamily => 'RedHat' }}
 
     describe 'el5.x' do
-      before { facts[:lsbmajdistrelease] = '5' }
+      before { facts[:operatingsystemmajrelease] = '5' }
 
       it { should include_class('ipmi::params') }
     end
 
     describe 'el6.x' do
-      before { facts[:lsbmajdistrelease] = '6' }
+      before { facts[:operatingsystemmajrelease] = '6' }
   
       it { should include_class('ipmi::params') }
     end
 
-    describe 'unsupported lsbmajdistrelease' do
-      before { facts[:lsbmajdistrelease] = '7' }
+    describe 'unsupported operatingsystemmajrelease' do
+      before { facts[:operatingsystemmajrelease] = '7' }
 
       it 'should fail' do
         expect { should include_class('ipmi::params') }.
-          to raise_error(Puppet::Error, /not supported on lsbmajdistrelease 7/)
+          to raise_error(Puppet::Error, /not supported on operatingsystemmajrelease 7/)
       end
     end
   end

--- a/spec/classes/ipmi_spec.rb
+++ b/spec/classes/ipmi_spec.rb
@@ -6,7 +6,7 @@ describe 'ipmi', :type => :class do
     let :facts do
       {
         :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
+        :operatingsystemmajrelease => '6',
       }
     end
 


### PR DESCRIPTION
Instead use $::operatingsystemmajrelease as this fact is not dependant on
redhat-lsb being present on the system.
