### PR TITLE
Add support for enabling the IPMI watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Usage
 class { 'ipmi':
   service_ensure         => 'running', # default is 'running'
   ipmievd_service_ensure => 'running', # default is 'stopped'
+  watchdog               => true,      # default is false
 }
 ```
 
@@ -69,6 +70,11 @@ Controls the state of the `ipmi` service.
 
 Controls the state of the `ipmievd` service.
 
+##### `watchdog`
+
+`Boolean` defaults to: `false`
+
+Controls whether the IPMI watchdog is enabled.
 
 Limitations
 -----------

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,18 @@
+# == Class: ipmi::config
+#
+# This class should be considered private.
+#
+class ipmi::config {
+
+  $watchdog_real = $::ipmi::watchdog ? {
+    true    => 'yes',
+    default => 'no',
+  }
+
+  augeas { '/etc/sysconfig/ipmi':
+    context => '/files/etc/sysconfig/ipmi',
+    changes => [
+      "set IPMI_WATCHDOG ${watchdog_real}",
+    ],
+  }
+}

--- a/spec/classes/ipmi_spec.rb
+++ b/spec/classes/ipmi_spec.rb
@@ -14,6 +14,15 @@ describe 'ipmi', :type => :class do
 #      it { should contain_class('ipmi') }
       it { should contain_class('ipmi::params') }
       it { should contain_class('ipmi::install') }
+      it { should contain_class('ipmi::config') }
+      it do
+        should contain_augeas('/etc/sysconfig/ipmi').with({
+          'context' => '/files/etc/sysconfig/ipmi',
+          'changes' => [
+            'set IPMI_WATCHDOG no',
+          ],
+        })
+      end
       it do
         should contain_class('ipmi::service::ipmi').with({
           :ensure => 'running',
@@ -34,6 +43,15 @@ describe 'ipmi', :type => :class do
 #      it { should contain_class('ipmi') }
       it { should contain_class('ipmi::params') }
       it { should contain_class('ipmi::install') }
+      it { should contain_class('ipmi::config') }
+      it do
+        should contain_augeas('/etc/sysconfig/ipmi').with({
+          'context' => '/files/etc/sysconfig/ipmi',
+          'changes' => [
+            'set IPMI_WATCHDOG no',
+          ],
+        })
+      end
       it do
         should contain_class('ipmi::service::ipmi').with({
           :ensure => 'running',
@@ -54,6 +72,15 @@ describe 'ipmi', :type => :class do
 #      it { should contain_class('ipmi') }
       it { should contain_class('ipmi::params') }
       it { should contain_class('ipmi::install') }
+      it { should contain_class('ipmi::config') }
+      it do
+        should contain_augeas('/etc/sysconfig/ipmi').with({
+          'context' => '/files/etc/sysconfig/ipmi',
+          'changes' => [
+            'set IPMI_WATCHDOG no',
+          ],
+        })
+      end
       it do
         should contain_class('ipmi::service::ipmi').with({
           :ensure => 'stopped',
@@ -84,6 +111,15 @@ describe 'ipmi', :type => :class do
 #      it { should contain_class('ipmi') }
       it { should contain_class('ipmi::params') }
       it { should contain_class('ipmi::install') }
+      it { should contain_class('ipmi::config') }
+      it do
+        should contain_augeas('/etc/sysconfig/ipmi').with({
+          'context' => '/files/etc/sysconfig/ipmi',
+          'changes' => [
+            'set IPMI_WATCHDOG no',
+          ],
+        })
+      end
       it do
         should contain_class('ipmi::service::ipmi').with({
           :ensure => 'running',
@@ -104,6 +140,15 @@ describe 'ipmi', :type => :class do
 #      it { should contain_class('ipmi') }
       it { should contain_class('ipmi::params') }
       it { should contain_class('ipmi::install') }
+      it { should contain_class('ipmi::config') }
+      it do
+        should contain_augeas('/etc/sysconfig/ipmi').with({
+          'context' => '/files/etc/sysconfig/ipmi',
+          'changes' => [
+            'set IPMI_WATCHDOG no',
+          ],
+        })
+      end
       it do
         should contain_class('ipmi::service::ipmi').with({
           :ensure => 'running',
@@ -127,6 +172,73 @@ describe 'ipmi', :type => :class do
         }.to raise_error(Puppet::Error, /does not match/)
       end
     end
+
+    describe 'watchdog => true' do
+      let(:params) {{ :watchdog => true }}
+
+      it { should contain_class('ipmi::params') }
+      it { should contain_class('ipmi::install') }
+      it { should contain_class('ipmi::config') }
+      it do
+        should contain_augeas('/etc/sysconfig/ipmi').with({
+          'context' => '/files/etc/sysconfig/ipmi',
+          'changes' => [
+            'set IPMI_WATCHDOG yes',
+          ],
+        })
+      end
+      it do
+        should contain_class('ipmi::service::ipmi').with({
+          :ensure => 'running',
+          :enable => true,
+        })
+      end
+      it do
+        should contain_class('ipmi::service::ipmievd').with({
+          :ensure => 'stopped',
+          :enable => false,
+        })
+      end
+    end
+
+    describe 'watchdog => false' do
+      let(:params) {{ :watchdog => false }}
+
+      it { should contain_class('ipmi::params') }
+      it { should contain_class('ipmi::install') }
+      it { should contain_class('ipmi::config') }
+      it do
+        should contain_augeas('/etc/sysconfig/ipmi').with({
+          'context' => '/files/etc/sysconfig/ipmi',
+          'changes' => [
+            'set IPMI_WATCHDOG no',
+          ],
+        })
+      end
+      it do
+        should contain_class('ipmi::service::ipmi').with({
+          :ensure => 'running',
+          :enable => true,
+        })
+      end
+      it do
+        should contain_class('ipmi::service::ipmievd').with({
+          :ensure => 'stopped',
+          :enable => false,
+        })
+      end
+    end
+
+    describe 'watchdog => invalid-string' do
+      let(:params) {{ :watchdog => 'invalid-string' }}
+
+      it 'should fail' do
+        expect {
+          should contain_class('ipmi')
+        }.to raise_error(Puppet::Error, /is not a boolean/)
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This PR adds support for enabling the IPMI watchdog, (on RH systems at least by setting IPMI_WATCHDOG=yes in `/etc/sysconfig/ipmi`).

I also used the anchor pattern to make sure the containment worked properly.
