### PR TITLE
Add IPMI facts compatible with The Foreman

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Puppet ipmi Module
 3. [Usage](#usage)
     * [Example](#example)
     * [Classes](#classes)
-4. [Limitations](#limitations)
+4. [Additional Facts](#additional-facts)
+5. [Limitations](#limitations)
     * [Tested Platforms](#tested-platforms)
-5. [Versioning](#versioning)
-6. [Support](#support)
-7. [See Also](#see-also)
+6. [Versioning](#versioning)
+7. [Support](#support)
+8. [See Also](#see-also)
 
 
 Overview
@@ -27,10 +28,12 @@ Manages the OpenIPMI package
 Description
 -----------
 
-Installs the [OpemIPMI](http://openipmi.sourceforge.net/) package and enables
-the `ipmi` service.  This loads the kernel drivers needed for communicating
-with the BMC from user space.
-
+Installs the [OpemIPMI](http://openipmi.sourceforge.net/) package,
+provides IPMI facts in a format compatible with
+[The Foreman](www.theforeman.org)'s
+[BMC features](www.theforeman.org/manuals/latest/index.html#4.3.3BMC)
+and enables the `ipmi` service. The latter loads the kernel drivers
+needed for communicating with the BMC from user space.
 
 Usage
 -----
@@ -75,6 +78,35 @@ Controls the state of the `ipmievd` service.
 `Boolean` defaults to: `false`
 
 Controls whether the IPMI watchdog is enabled.
+
+Additional Facts
+----------------
+
+This module provides additional facts for Facter with the following
+format:
+
+```
+ipmi1_gateway => 192.168.10.1
+ipmi1_ipaddress => 192.168.10.201
+ipmi1_ipaddress_source => Static Address
+ipmi1_macaddress => 00:30:48:c9:64:2a
+ipmi1_subnet_mask => 255.255.255.0
+```
+
+where the 1 in `ipmi1` corresponds to the channel according to
+`ipmitool lan print`.
+
+Additionally for compatibility with The Foreman, the first IPMI
+interface (i.e. the one from `ipmi lan print 1`) gets all facts
+repeated as just `ipmi_foo`:
+
+```
+ipmi_gateway => 192.168.10.1
+ipmi_ipaddress => 192.168.10.201
+ipmi_ipaddress_source => Static Address
+ipmi_macaddress => 00:30:48:c9:64:2a
+ipmi_subnet_mask => 255.255.255.0
+```
 
 Limitations
 -----------

--- a/lib/facter/ipmi.rb
+++ b/lib/facter/ipmi.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+#
+# IPMI facts, in a format compatible with The Foreman
+#
+# Sending these facts to a puppetmaster equipped with RedHat's Foreman
+# will cause the latter to create the BMC interfaces the next time the
+# Puppet agent runs. One then only has to manually add the access
+# credentials, and presto, you can run basic IPMI actions (e.g. reboot
+# to PXE) from The Foreman's web UI.
+#
+# === Fact Format
+#
+#     ipmi1_ipaddress = 192.168.101.1
+#     ipmi1_subnet_mask = 255.255.255.0
+#     ...
+#
+# where the 1 in "ipmi1" corresponds to the ID of the BMC according to
+# ipmitool lan print.
+#
+# Additionally for compatibility with The Foreman, the first IPMI
+# interface (i.e. the one from ipmi lan print 1) gets all facts
+# repeated as just ipmi_foo:
+#
+#     ipmi_ipaddress = 192.168.101.1
+#     ipmi_subnet_mask = 255.255.255.0
+#     ...
+#
+
+class IPMIChannel
+  public
+  def initialize channel_nr
+    @channel_nr = channel_nr
+    @has_facts = false
+  end
+
+  def load_facts
+    ipmitool_output = `env - $(which ipmitool) lan print #{@channel_nr} 2>&1`
+    parse_ipmitool_output ipmitool_output
+    if ipmitool_output =~ /Invalid channel/ then
+      return false
+    elsif not @has_facts
+      Facter.debug(ipmitool_output)
+      return false
+    else
+      return true
+    end
+  end
+
+  private
+  def parse_ipmitool_output ipmitool_output
+    ipmitool_output.each_line do |line|
+      case line.strip
+      when /^IP Address\s*:\s+(\S.*)/
+        add_ipmi_fact("ipaddress", $1)
+      when /^IP Address Source\s*:\s+(\S.*)/
+        add_ipmi_fact("ipaddress_source", $1)
+      when /^Subnet Mask\s*:\s+(\S.*)/
+        add_ipmi_fact("subnet_mask", $1)
+      when /^MAC Address\s*:\s+(\S.*)/
+        add_ipmi_fact("macaddress", $1)
+      when /^Default Gateway IP\s*:\s+(\S.*)/
+        add_ipmi_fact("gateway", $1)
+      end
+    end
+  end
+
+  def add_ipmi_fact name, value
+    fact_names = []
+    if @channel_nr == 1 then fact_names.push("ipmi_#{name}") end
+    fact_names.push("ipmi#{@channel_nr}_#{name}")
+    fact_names.each do |name|
+      Facter.add(name) do
+        confine :kernel => "Linux"
+        setcode do
+          value
+        end
+      end
+    end
+    @has_facts = true
+  end
+end
+
+channel_nr = 1
+while true
+  break unless IPMIChannel.new(channel_nr).load_facts
+  channel_nr += 1
+end


### PR DESCRIPTION
Additional facts for Facter make it much easier to get The Foreman's IPMI support working (see http://snag.gy/GQk7l.jpg ); one only needs to input the IPMI login and password manually for the BMC interface, the rest is now picked up automatically. That feature was previously available only if the provisioned host was first booted into the discovery image (using the [`foreman_discovery` plugin](https://github.com/theforeman/foreman_discovery)), and is now made available to all hosts running Puppet.