### PR TITLE
F/bmc lan conf fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Puppet ipmi Module
 Overview
 --------
 
-Manages the OpenIPMI package
+Manages IPMI
 
 
 Description
@@ -29,7 +29,7 @@ Description
 
 Installs the [OpemIPMI](http://openipmi.sourceforge.net/) package and enables
 the `ipmi` service.  This loads the kernel drivers needed for communicating
-with the BMC from user space.
+with the BMC from user space. Moreover, two facts are made available to the system.
 
 
 Usage
@@ -76,6 +76,13 @@ Controls the state of the `ipmievd` service.
 
 Controls whether the IPMI watchdog is enabled.
 
+### Facts
+
+This module provides the following facts:
+
+* kmod_isloaded_ipmi_si (Boolean) `true` if kernel module is loaded, `false` otherwise
+* bmc_lan_conf (Hash) returns LAN configuration of BMC. Example: `{"IP_Address"=>"192.168.1.1", "Subnet_Mask"=>"255.255.255.0", "IP_Address_Source"=>"Static", "Default_Gateway_MAC_Address"=>"00:00:00:00:00:00", "Backup_Gateway_IP_Address"=>"0.0.0.0", "Backup_Gateway_MAC_Address"=>"00:00:00:00:00:00", "MAC_Address"=>"FF:FF:FF:FF:FF:FF", "Default_Gateway_IP_Address"=>"192.168.1.254"}`
+
 Limitations
 -----------
 
@@ -107,3 +114,4 @@ See Also
 --------
 
 * [OpenIPMI](http://openipmi.sourceforge.net/)
+* [FreeIPMI](http://www.gnu.org/software/freeipmi/)

--- a/lib/facter/bmc_lan_conf.rb
+++ b/lib/facter/bmc_lan_conf.rb
@@ -19,6 +19,7 @@
 Facter.add(:bmc_lan_conf, :timeout => 5) do
   confine :kernel => "Linux"
   confine :is_virtual => "false"
+  confine :kmod_isloaded_ipmi_si => "true"
   setcode do
     if Facter::Util::Resolution.which('bmc-config')
       output = Facter::Util::Resolution.exec("bmc-config --checkout --section Lan_Conf --disable-auto-probe").lines.find_all { |l| l =~ /^\s+[^#]/}

--- a/lib/facter/bmc_lan_conf.rb
+++ b/lib/facter/bmc_lan_conf.rb
@@ -1,0 +1,31 @@
+# Fact: bmc_lan_conf
+#
+# Purpose: get IP of BMC
+#
+# Resolution:
+#   Uses freeipmi query tool
+#   bmc-config --checkout -e Lan_Conf:IP_Address
+#   Section Lan_Conf
+#           ## Give valid IP address
+#           IP_Address                                    192.168.168.17
+#   EndSection
+#
+# Caveats:
+#   Needs freeipmi. If you find a better way using OpenIPMI
+# please tell me
+#
+# Notes:
+#   None
+Facter.add(:bmc_lan_conf, :timeout => 5) do
+  confine :kernel => "Linux"
+  confine :is_virtual => false
+  setcode do
+    if Facter::Util::Resolution.which('bmc-config')
+      output = Facter::Util::Resolution.exec("bmc-config --checkout --section Lan_Conf --disable-auto-probe").lines.find_all { |l| l =~ /^\s+[^#]/}
+      if ! output.empty?
+        Hash[output.map { |e| e.split }]
+      end
+    end
+  end
+end
+

--- a/lib/facter/bmc_lan_conf.rb
+++ b/lib/facter/bmc_lan_conf.rb
@@ -18,8 +18,7 @@
 #   None
 Facter.add(:bmc_lan_conf, :timeout => 5) do
   confine :kernel => "Linux"
-  confine :is_virtual => "false"
-  confine :kmod_isloaded_ipmi_si => "true"
+  confine :kmod_isloaded_ipmi_si => true
   setcode do
     if Facter::Util::Resolution.which('bmc-config')
       output = Facter::Util::Resolution.exec("bmc-config --checkout --section Lan_Conf --disable-auto-probe").lines.find_all { |l| l =~ /^\s+[^#]/}

--- a/lib/facter/bmc_lan_conf.rb
+++ b/lib/facter/bmc_lan_conf.rb
@@ -18,7 +18,7 @@
 #   None
 Facter.add(:bmc_lan_conf, :timeout => 5) do
   confine :kernel => "Linux"
-  confine :is_virtual => false
+  confine :is_virtual => "false"
   setcode do
     if Facter::Util::Resolution.which('bmc-config')
       output = Facter::Util::Resolution.exec("bmc-config --checkout --section Lan_Conf --disable-auto-probe").lines.find_all { |l| l =~ /^\s+[^#]/}

--- a/lib/facter/kmod_isloaded_ipmi_si.rb
+++ b/lib/facter/kmod_isloaded_ipmi_si.rb
@@ -1,0 +1,21 @@
+# Fact: kmod_isloaded_ipmi_si
+#
+# Purpose: report kernel module status
+#
+# Resolution:
+#   Uses lsmod to list kernel modules
+#
+Facter.add(:kmod_isloaded_ipmi_si, :timeout => 5) do
+  confine :kernel => "Linux"
+  if Facter::Util::Resolution.which('lsmod')
+    lsmod_output = Facter::Util::Resolution.exec('lsmod')
+    if lsmod_output[0]
+      is_loaded = !!(/^ipmi_si\s/.match(lsmod_output))
+      setcode do
+        is_loaded
+      end
+    else
+      Facter.debug("Running lsmod didn't work out")
+    end
+  end
+end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,11 +8,11 @@ class ipmi::params {
       case $::operatingsystemmajrelease {
         5: {
           # el5.x
-          $ipmi_package = ['OpenIPMI', 'OpenIPMI-tools']
+          $ipmi_package = ['OpenIPMI', 'OpenIPMI-tools', 'freeipmi']
         }
         6, 7: {
           # el6.x
-          $ipmi_package = ['OpenIPMI', 'ipmitool']
+          $ipmi_package = ['OpenIPMI', 'ipmitool', 'freeipmi']
         }
         default: {
           fail("Module ${module_name} is not supported on operatingsystemmajrelease ${::operatingsystemmajrelease}")


### PR DESCRIPTION
This adds two facts to the module.
I chose to pull in the `freeipmi` package because it's much more robust and simple to pull BMC parameters from the KCS interface.
Please tell me what you think