### PR TITLE
Silence debug output by default

### DIFF
--- a/lib/facter/ipmi.rb
+++ b/lib/facter/ipmi.rb
@@ -34,7 +34,7 @@ class IPMIChannel
   end
 
   def load_facts
-    ipmitool_output = `env - $(which ipmitool) lan print #{@channel_nr} 2>&1`
+    ipmitool_output = `env - $(which ipmitool 2>/dev/null) lan print #{@channel_nr} 2>&1`
     parse_ipmitool_output ipmitool_output
     if ipmitool_output =~ /Invalid channel/ then
       return false


### PR DESCRIPTION
If ipmitool isn't installed we got no ouput to debug - redirect
the stderr output from the 'which' subshell to null