### PR TITLE
quote the numbers in the case statement

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,12 +6,10 @@ class ipmi::params {
   case $::osfamily {
     'redhat': {
       case $::operatingsystemmajrelease {
-        5: {
-          # el5.x
+        '5': {
           $ipmi_package = ['OpenIPMI', 'OpenIPMI-tools']
         }
-        6, 7: {
-          # el6.x
+        '6', '7': {
           $ipmi_package = ['OpenIPMI', 'ipmitool']
         }
         default: {

--- a/spec/classes/ipmi_install_spec.rb
+++ b/spec/classes/ipmi_install_spec.rb
@@ -13,7 +13,7 @@ describe 'ipmi::install', :type => :class do
     end
 
     describe 'el5.x' do
-      before { facts[:operatingsystemmajrelease] = 5 }
+      before { facts[:operatingsystemmajrelease] = '5' }
 
 #      it { should contain_class('ipmi::install') }
       it { should contain_package('OpenIPMI').with_ensure('present') }
@@ -21,7 +21,7 @@ describe 'ipmi::install', :type => :class do
     end
 
     describe 'el6.x' do
-      before { facts[:operatingsystemmajrelease] = 6 }
+      before { facts[:operatingsystemmajrelease] = '6' }
 
 #      it { should contain_class('ipmi::install') }
       it { should contain_package('OpenIPMI').with_ensure('present') }
@@ -29,7 +29,7 @@ describe 'ipmi::install', :type => :class do
     end
 
     describe 'el7.x' do
-      before { facts[:operatingsystemmajrelease] = 7 }
+      before { facts[:operatingsystemmajrelease] = '7' }
 
 #      it { should contain_class('ipmi::install') }
       it { should contain_package('OpenIPMI').with_ensure('present') }

--- a/spec/classes/ipmi_params_spec.rb
+++ b/spec/classes/ipmi_params_spec.rb
@@ -5,25 +5,25 @@ describe 'ipmi::params', :type => :class do
     let(:facts) {{ :osfamily => 'RedHat' }}
 
     describe 'el5.x' do
-      before { facts[:operatingsystemmajrelease] = 5 }
+      before { facts[:operatingsystemmajrelease] = '5' }
 
 #      it { should contain_class('ipmi::params') }
     end
 
     describe 'el6.x' do
-      before { facts[:operatingsystemmajrelease] = 6 }
+      before { facts[:operatingsystemmajrelease] = '6' }
 
 #      it { should contain_class('ipmi::params') }
     end
 
     describe 'el7.x' do
-      before { facts[:operatingsystemmajrelease] = 7 }
+      before { facts[:operatingsystemmajrelease] = '7' }
 
 #      it { should contain_class('ipmi::params') }
     end
 
     describe 'unsupported operatingsystemmajrelease' do
-      before { facts[:operatingsystemmajrelease] = 1 }
+      before { facts[:operatingsystemmajrelease] = '1' }
 
       it 'should fail' do
         expect { should contain_class('ipmi::params') }.

--- a/spec/classes/ipmi_spec.rb
+++ b/spec/classes/ipmi_spec.rb
@@ -6,7 +6,7 @@ describe 'ipmi', :type => :class do
     let :facts do
       {
         :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease => 6,
+        :operatingsystemmajrelease => '6',
       }
     end
 


### PR DESCRIPTION
This module is failing on puppet 4 because it doesn't have quotes around the numbers for operatingsystemmajrelease.

```
[root@memcached vagrant]# puppet --version
4.3.1
[root@memcached vagrant]# cat ./foo.pp
case $::operatingsystemmajrelease {
  6, 7: {
    notify {"${::operatingsystemmajrelease} no quotes":}
  }	
  default: {
    fail("Module ${module_name} is not supported on operatingsystemmajrelease ${::operatingsystemmajrelease}")
  }
}

[root@memcached vagrant]# puppet apply ./foo.pp
Error: Evaluation Error: Error while evaluating a Function Call, Module  is not supported on operatingsystemmajrelease 7 at /home/vagrant/foo.pp:6:5 on node memcached.example.net
[root@memcached vagrant]# 
```

Something in puppet 4 must've changed becaue it works fine in puppet 3.  Interesting this is if you run the below code on puppet 3.x, the case statement stops at the 'no quote' statement whereas on puppet 4.x it stops at the 'with quotes' statement. 


```
[root@memcached vagrant]# puppet --version
4.3.1
[root@memcached vagrant]# cat ./foo.pp
case $::operatingsystemmajrelease {
  6, 7: {
    notify {"${::operatingsystemmajrelease} no quotes":}
  }	
  '6', '7': {
    notify {"${::operatingsystemmajrelease} with quotes":}
  }
  default: {
    fail("Module ${module_name} is not supported on operatingsystemmajrelease ${::operatingsystemmajrelease}")
  }
}

[root@memcached vagrant]# puppet apply ./foo.pp
Notice: Compiled catalog for memcached.example.net in environment production in 0.05 seconds
Notice: 7 with quotes
Notice: /Stage[main]/Main/Notify[7 with quotes]/message: defined 'message' as '7 with quotes'
Notice: Applied catalog in 0.02 seconds
[root@memcached vagrant]# 
```