### PR TITLE
Fix "Missing "openipmi" service on Debian 6, 7, 8"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,10 +32,16 @@ class ipmi (
   include ::ipmi::install
   include ::ipmi::config
 
-  class { '::ipmi::service::ipmi':
-    ensure            => $service_ensure,
-    enable            => $enable_ipmi,
-    ipmi_service_name => $ipmi::params::ipmi_service_name,
+  if ( ($::osfamily == 'Debian') and ($::operatingsystemmajrelease > 8) ) or
+       ($::osfamily == 'RedHat') and ($::operatingsystemmajrelease > 6) )
+     ){
+    class { '::ipmi::service::ipmi':
+      ensure            => $service_ensure,
+      enable            => $enable_ipmi,
+      ipmi_service_name => $ipmi::params::ipmi_service_name,
+      notify            => Class['::ipmi::service::ipmievd']
+      subscribe         => Class['::ipmi::']
+    }
   }
 
   class { '::ipmi::service::ipmievd':
@@ -46,9 +52,11 @@ class ipmi (
   anchor { 'ipmi::begin': }
   anchor { 'ipmi::end': }
 
-  Anchor['ipmi::begin'] -> Class['::ipmi::install'] ~> Class['::ipmi::config']
-    ~> Class['::ipmi::service::ipmi'] ~> Class['::ipmi::service::ipmievd']
+  Anchor['ipmi::begin'] -> Class['::ipmi::install'] ~> Class['::ipmi::]
+    ~> Class['::ipmi::service::ipmievd']
     -> Anchor['ipmi::end']
+
+
 
   if $snmps {
     create_resources('ipmi::snmp', $snmps)


### PR DESCRIPTION
Upstream issue #29