### PR TITLE
ipmi_<name> facts from first found LAN channel

### DIFF
--- a/lib/facter/ipmi.rb
+++ b/lib/facter/ipmi.rb
@@ -59,7 +59,7 @@ class IPMIChannel
 
   def add_ipmi_fact name, value
     fact_names = []
-    if @channel_nr == 1 then fact_names.push("ipmi_#{name}") end
+    if not fact_names.include?("ipmi_#{name}") then fact_names.push("ipmi_#{name}") end
     fact_names.push("ipmi#{@channel_nr}_#{name}")
     fact_names.each do |name|
       Facter.add(name) do


### PR DESCRIPTION
I find some of my servers have ipmi running on channel #2 only (plugged into different physical port maybe - who knows).
so the impi_ipaddress etc facts (which come from channel #1) are not set. as channel #1 is not configured.

instead of always taking channel #1 for these, could we take 'the first found LAN channel' instead? (asside: this is the behaviour when running 'ipmitool lan print' without picking a channel).

have put in a suggested change for this. think it would work to only set each of the ipmi_<name> facts if not set so far.

cheers,