### PR TITLE
Auto lan channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Usage
 Create a user with admin privileges (default):
 ```puppet
    ipmi::user { 'newuser1':
-     user     => 'newuser1',
-     password => 'password1',
-     user_id  => 4,
+     user        => 'newuser1',
+     password    => 'password1',
+     user_id     => 4,
+     lan_channel => 1,
    }
 ```
 Create a user with operator privileges:

--- a/lib/facter/ipmi.rb
+++ b/lib/facter/ipmi.rb
@@ -45,6 +45,7 @@ class IPMIChannel
       case line.strip
       when /^IP Address\s*:\s+(\S.*)/
         add_ipmi_fact("ipaddress", $1)
+        add_ipmi_fact("lan_channel", @channel_nr)
       when /^IP Address Source\s*:\s+(\S.*)/
         add_ipmi_fact("ipaddress_source", $1)
       when /^Subnet Mask\s*:\s+(\S.*)/

--- a/lib/facter/ipmi.rb
+++ b/lib/facter/ipmi.rb
@@ -59,7 +59,7 @@ class IPMIChannel
 
   def add_ipmi_fact name, value
     fact_names = []
-    if @channel_nr == 1 then fact_names.push("ipmi_#{name}") end
+    if not fact_names.include?("ipmi_#{name}") then fact_names.push("ipmi_#{name}") end
     fact_names.push("ipmi#{@channel_nr}_#{name}")
     fact_names.each do |name|
       Facter.add(name) do

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -6,7 +6,7 @@ define ipmi::network (
   $netmask = '255.255.255.0',
   $gateway = '0.0.0.0',
   $type = 'dhcp',
-  $lan_channel = 1,
+  $lan_channel = $::ipmi_lan_channel,
 )
 {
   require ::ipmi

--- a/manifests/snmp.pp
+++ b/manifests/snmp.pp
@@ -3,7 +3,7 @@
 
 define ipmi::snmp (
   $snmp = 'public',
-  $lan_channel = 1,
+  $lan_channel = $::ipmi_lan_channel,
 )
 {
   require ::ipmi


### PR DESCRIPTION
sets a fact for the first found lan channel - 'ipmi_lan_channel',
and uses this as default lan_channel in user/netwrok/snmp.

handy for servers where the lan channel is not '1', eg fujitsu.

cheers,
