### PR TITLE
Set the ipmi service to stopped by default if no ipmi devices

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,7 +3,7 @@ ipmi::packages:
   - ipmitool
 ipmi::config_file: /etc/default/openipmi
 ipmi::service_name: openipmi
-ipmi::service_ensure: running
+ipmi::service_ensure: "%{facts.ipmitool_mc_info.IPMI_Puppet_Service_Recommend}"
 ipmi::ipmievd_service_name: ipmievd
 ipmi::ipmievd_service_ensure: stopped
 ipmi::watchdog: false

--- a/lib/facter/ipmitool_mc_info.rb
+++ b/lib/facter/ipmitool_mc_info.rb
@@ -6,6 +6,7 @@ Facter.add(:ipmitool_mc_info) do
   confine kernel: 'Linux'
 
   retval = {}
+  retval['IPMI_Puppet_Service_Recommend'] = 'stopped'
 
   if Facter::Util::Resolution.which('ipmitool')
     ipmitool_output = Facter::Util::Resolution.exec('ipmitool mc info 2>/dev/null')
@@ -15,6 +16,9 @@ Facter.add(:ipmitool_mc_info) do
       if info.length == 2 && (info[1].strip != '')
         retval[info[0].strip] = info[1].strip
       end
+    end
+    if retval.fetch('Device Available', 'no') == 'yes'
+      retval['IPMI_Puppet_Service_Recommend'] = 'running'
     end
   end
 

--- a/spec/classes/ipmi_spec.rb
+++ b/spec/classes/ipmi_spec.rb
@@ -24,7 +24,7 @@ end
 describe 'ipmi', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { facts.merge(ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' }) }
 
       case facts[:os]['family']
       when 'RedHat'

--- a/spec/defines/ipmi_network_spec.rb
+++ b/spec/defines/ipmi_network_spec.rb
@@ -8,6 +8,7 @@ describe 'ipmi::network', type: :define do
       operatingsystem: 'RedHat',
       osfamily: 'redhat',
       operatingsystemmajrelease: '7',
+      ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
     }
   end
 

--- a/spec/defines/ipmi_snmp_spec.rb
+++ b/spec/defines/ipmi_snmp_spec.rb
@@ -8,6 +8,7 @@ describe 'ipmi::snmp', type: :define do
       operatingsystem: 'RedHat',
       osfamily: 'redhat',
       operatingsystemmajrelease: '7',
+      ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
     }
   end
 

--- a/spec/defines/ipmi_user_spec.rb
+++ b/spec/defines/ipmi_user_spec.rb
@@ -8,6 +8,7 @@ describe 'ipmi::user', type: :define do
       operatingsystem: 'RedHat',
       osfamily: 'redhat',
       operatingsystemmajrelease: '7',
+      ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
     }
   end
 

--- a/spec/unit/facter/ipmitool_mc_info_spec.rb
+++ b/spec/unit/facter/ipmitool_mc_info_spec.rb
@@ -47,7 +47,7 @@ Aux Firmware Rev Info     :
     end
 
     it do
-      expect(fact.value).to eq({})
+      expect(fact.value).to eq({ 'IPMI_Puppet_Service_Recommend' => 'stopped' })
     end
   end
 
@@ -64,6 +64,7 @@ Aux Firmware Rev Info     :
           'Device Revision' => '1',
           'Firmware Revision' => '2.49',
           'IPMI Version' => '2.0',
+          'IPMI_Puppet_Service_Recommend' => 'running',
           'Manufacturer ID' => '10876',
           'Manufacturer Name' => 'Supermicro',
           'Product ID' => '43707 (0xaabb)',


### PR DESCRIPTION
This alters the default state to `stopped` if no IPMI devices are detected.