### PR TITLE
Bumps stdlib requirements to next major version.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,6 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -42,7 +41,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7",
         "8"
       ]
     }
@@ -50,7 +48,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
Removes support for Debian 7 and Scientific 5 as it has been
removed from stdlib 5.0.0.