### PR TITLE
Permit password as Sensitive string

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -18,7 +18,7 @@
 #   SuperMicro IPMI, user id 2 is reserved for the ADMIN user.
 #
 define ipmi::user (
-  String $password,
+  Variant[Sensitive[String[1]], String[1]] $password,
   String $user     = 'root',
   Integer $priv    = 4,
   Integer $user_id = 3,
@@ -31,6 +31,13 @@ define ipmi::user (
     3: { $privilege = 'OPERATOR' }
     4: { $privilege = 'ADMINISTRATOR' }
     default: { fail('invalid privilege level specified') }
+  }
+
+  if $password =~ Sensitive {
+    # unwrap before Puppet 6.24 can only be called on Sensitive values
+    $real_password = $password.unwrap
+  } else {
+    $real_password = $password
   }
 
   exec { "ipmi_user_enable_${title}":
@@ -51,8 +58,8 @@ define ipmi::user (
   }
 
   exec { "ipmi_user_setpw_${title}":
-    command => "/usr/bin/ipmitool user set password ${user_id} \'${password}\'",
-    unless  => "/usr/bin/ipmitool user test ${user_id} 16 \'${password}\'",
+    command => "/usr/bin/ipmitool user set password ${user_id} \'${real_password}\'",
+    unless  => "/usr/bin/ipmitool user test ${user_id} 16 \'${real_password}\'",
     notify  => [Exec["ipmi_user_enable_${title}"], Exec["ipmi_user_enable_sol_${title}"], Exec["ipmi_user_channel_setaccess_${title}"]],
   }
 

--- a/spec/defines/ipmi_user_spec.rb
+++ b/spec/defines/ipmi_user_spec.rb
@@ -64,6 +64,33 @@ describe 'ipmi::user', type: :define do
     it { is_expected.to contain_exec('ipmi_user_channel_setaccess_newuser').with('refreshonly' => 'true') }
   end
 
+  context 'when deploying with all params and a sensitive password' do
+    let(:params) do
+      {
+        user: 'newuser1',
+        password: sensitive('password'),
+        priv: 3,
+        user_id: 4,
+      }
+    end
+
+    it { is_expected.to contain_exec('ipmi_user_enable_newuser').with('refreshonly' => 'true') }
+
+    it { is_expected.to contain_exec('ipmi_user_add_newuser').that_notifies('Exec[ipmi_user_priv_newuser]') }
+    it { is_expected.to contain_exec('ipmi_user_add_newuser').that_notifies('Exec[ipmi_user_setpw_newuser]') }
+
+    it { is_expected.to contain_exec('ipmi_user_priv_newuser').that_notifies('Exec[ipmi_user_enable_newuser]') }
+    it { is_expected.to contain_exec('ipmi_user_priv_newuser').that_notifies('Exec[ipmi_user_enable_sol_newuser]') }
+    it { is_expected.to contain_exec('ipmi_user_priv_newuser').that_notifies('Exec[ipmi_user_channel_setaccess_newuser]') }
+
+    it { is_expected.to contain_exec('ipmi_user_setpw_newuser').that_notifies('Exec[ipmi_user_enable_newuser]') }
+    it { is_expected.to contain_exec('ipmi_user_setpw_newuser').that_notifies('Exec[ipmi_user_enable_sol_newuser]') }
+    it { is_expected.to contain_exec('ipmi_user_setpw_newuser').that_notifies('Exec[ipmi_user_channel_setaccess_newuser]') }
+
+    it { is_expected.to contain_exec('ipmi_user_enable_sol_newuser').with('refreshonly' => 'true') }
+    it { is_expected.to contain_exec('ipmi_user_channel_setaccess_newuser').with('refreshonly' => 'true') }
+  end
+
   describe 'when deploying with no params' do
     it 'fails and raise password required error' do
       expect { is_expected.to contain_exec('ipmi_user_enable_newuser') }.to raise_error(Puppet::Error, %r{password})


### PR DESCRIPTION
I'm casting all my passwords as Sensitive within `hiera`.  This should permit a Sensitive password without breaking the existing user base.