### PR TITLE
Stub out support for stdlib-9.x

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,5 +6,5 @@ class ipmi::install {
 
   include ipmi
 
-  ensure_packages($ipmi::packages)
+  stdlib::ensure_packages($ipmi::packages)
 }

--- a/metadata.json
+++ b/metadata.json
@@ -62,7 +62,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 9.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/augeas_core",


### PR DESCRIPTION
Fixes: https://github.com/jhoblitt/puppet-ipmi/issues/63

This is a breaking change due to incompatibility with stdlib 8.x.

My local tests fail on:

```
Failures:

  1) ipmi on almalinux-8-x86_64 is expected to compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile.with_all_deps }
       error during compilation: Evaluation Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/service: Could not autoload puppet/provider/service/bsd: Could not autoload puppet/provider/service/init: undefined method `downcase' for nil:NilClass (file: /tmp/foo/puppet-ipmi/spec/fixtures/modules/ipmi/manifests/service/ipmi.pp, line: 11, column: 3) on node leibniz.local
     # ./spec/classes/ipmi_spec.rb:38:in `block (4 levels) in <top (required)>'

```

Which I fear I do not understand...