### PR TITLE
ipmi::user: Mask passwords

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -67,9 +67,10 @@ define ipmi::user (
     }
 
     exec { "ipmi_user_setpw_${title}":
-      command => "/usr/bin/ipmitool user set password ${user_id} \'${real_password}\'",
-      unless  => "/usr/bin/ipmitool user test ${user_id} 16 \'${real_password}\'",
-      notify  => [Exec["ipmi_user_enable_${title}"], Exec["ipmi_user_enable_sol_${title}"], Exec["ipmi_user_channel_setaccess_${title}"]],
+      environment => ["PASSWORD=${real_password}"],
+      command     => "/usr/bin/ipmitool user set password ${user_id} \'\$PASSWORD\'",
+      unless      => "/usr/bin/ipmitool user test ${user_id} 16 \'\$PASSWORD\'",
+      notify      => [Exec["ipmi_user_enable_${title}"], Exec["ipmi_user_enable_sol_${title}"], Exec["ipmi_user_channel_setaccess_${title}"]],
     }
 
     exec { "ipmi_user_enable_sol_${title}":


### PR DESCRIPTION
If an exec command fails, then the entire command including passwords is included in the output.

The CR updates the commands that have a password to be Sensitive, ensuring they are redacted from output and logs.

