### PR TITLE
Add lan channel fact and user channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,21 +160,21 @@ formats:
 ```text
 ipmi => {
   default => {
-    channel => 1
-    gateway => 192.168.10.1
-    ipaddress => 192.168.10.201
-    ipaddress_source => Static Address
-    macaddress => 00:30:48:c9:64:2a
-    subnet_mask => 255.255.255.0
-  }
+    channel => 1,
+    gateway => 192.168.10.1,
+    ipaddress => 192.168.10.201,
+    ipaddress_source => Static Address,
+    macaddress => 00:30:48:c9:64:2a,
+    subnet_mask => 255.255.255.0,
+  },
   1 => {
-    channel => 1
-    gateway => 192.168.10.1
-    ipaddress => 192.168.10.201
-    ipaddress_source => Static Address
-    macaddress => 00:30:48:c9:64:2a
-    subnet_mask => 255.255.255.0
-  }
+    channel => 1,
+    gateway => 192.168.10.1,
+    ipaddress => 192.168.10.201,
+    ipaddress_source => Static Address,
+    macaddress => 00:30:48:c9:64:2a,
+    subnet_mask => 255.255.255.0,
+  },
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ Create a user with operator privileges:
     user_id  => 5,
   }
 ```
+Create a user with user privileges on a specific channel:
 
+```puppet
+  ipmi::user { 'newuser3':
+    user     => 'newuser3',
+    password => 'password3',
+    priv     => 2,
+    user_id  => 6,
+    channel  => 3,
+  }
+```
 Configure a static ip on IPMI lan channel 1:
 
 ```puppet

--- a/README.md
+++ b/README.md
@@ -154,7 +154,31 @@ Configure IPMI snmp string on lan channel 1:
 ## Additional Facts
 
 This module provides additional facts for Facter with the following
-format:
+formats:
+
+### Structured Format
+```text
+ipmi => {
+  default => {
+    channel => 1
+    gateway => 192.168.10.1
+    ipaddress => 192.168.10.201
+    ipaddress_source => Static Address
+    macaddress => 00:30:48:c9:64:2a
+    subnet_mask => 255.255.255.0
+  }
+  1 => {
+    channel => 1
+    gateway => 192.168.10.1
+    ipaddress => 192.168.10.201
+    ipaddress_source => Static Address
+    macaddress => 00:30:48:c9:64:2a
+    subnet_mask => 255.255.255.0
+  }
+}
+```
+
+### DEPRECATED Flat Format
 
 ```text
 ipmi1_gateway => 192.168.10.1

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Create a user with operator privileges:
     user_id  => 5,
   }
 ```
+
 Create a user with user privileges on a specific channel:
 
 ```puppet
@@ -76,6 +77,7 @@ Create a user with user privileges on a specific channel:
     channel  => 3,
   }
 ```
+
 Configure a static ip on IPMI lan channel 1:
 
 ```puppet
@@ -157,6 +159,7 @@ This module provides additional facts for Facter with the following
 formats:
 
 ### Structured Format
+
 ```text
 ipmi => {
   default => {

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -157,8 +157,9 @@ Default value: `'dhcp'`
 Data type: `Integer`
 
 Controls the lan channel of the IPMI network to be configured.
+Defaults to the first detected lan channel, starting at 1 ending at 11
 
-Default value: `1`
+Default value: `$facts['ipmi']['default']['channel']`
 
 ### <a name="ipmi--snmp"></a>`ipmi::snmp`
 
@@ -184,8 +185,9 @@ Default value: `'public'`
 Data type: `Integer`
 
 Controls the lan channel of the IPMI network on which snmp is to be configured.
+Defaults to the first detected lan channel, starting at 1 ending at 11
 
-Default value: `1`
+Default value: `$facts['ipmi']['default']['channel']`
 
 ### <a name="ipmi--user"></a>`ipmi::user`
 
@@ -200,6 +202,7 @@ The following parameters are available in the `ipmi::user` defined type:
 * [`enable`](#-ipmi--user--enable)
 * [`user_id`](#-ipmi--user--user_id)
 * [`password`](#-ipmi--user--password)
+* [`channel`](#-ipmi--user--channel)
 
 ##### <a name="-ipmi--user--user"></a>`user`
 
@@ -248,4 +251,13 @@ Data type: `Optional[Variant[Sensitive[String[1]], String[1]]]`
 Controls the password of the user to be created.
 
 Default value: `undef`
+
+##### <a name="-ipmi--user--channel"></a>`channel`
+
+Data type: `Integer`
+
+Controls the channel of the IPMI user to be configured.
+Defaults to the first detected lan channel, starting at 1 ending at 11
+
+Default value: `$facts['ipmi']['default']['channel']`
 

--- a/lib/facter/ipmi.rb
+++ b/lib/facter/ipmi.rb
@@ -46,7 +46,7 @@ class IPMIChannel
       case line.strip
       when %r{^IP Address\s*:\s+(\S.*)}
         add_ipmi_fact('ipaddress', Regexp.last_match(1))
-        add_ipmi_fact("lan_channel", @channel_nr)
+        add_ipmi_fact('lan_channel', @channel_nr)
       when %r{^IP Address Source\s*:\s+(\S.*)}
         add_ipmi_fact('ipaddress_source', Regexp.last_match(1))
       when %r{^Subnet Mask\s*:\s+(\S.*)}

--- a/lib/facter/ipmi.rb
+++ b/lib/facter/ipmi.rb
@@ -46,6 +46,7 @@ class IPMIChannel
       case line.strip
       when %r{^IP Address\s*:\s+(\S.*)}
         add_ipmi_fact('ipaddress', Regexp.last_match(1))
+        add_ipmi_fact("lan_channel", @channel_nr)
       when %r{^IP Address Source\s*:\s+(\S.*)}
         add_ipmi_fact('ipaddress_source', Regexp.last_match(1))
       when %r{^Subnet Mask\s*:\s+(\S.*)}
@@ -60,7 +61,9 @@ class IPMIChannel
 
   def add_ipmi_fact(name, value)
     fact_names = []
-    fact_names.push("ipmi_#{name}") if @channel_nr == 1
+    if not fact_names.include?("ipmi_#{name}") then
+      fact_names.push("ipmi_#{name}")
+    end
     fact_names.push("ipmi#{@channel_nr}_#{name}")
     fact_names.each do |n|
       Facter.add(n) do

--- a/lib/facter/ipmi.rb
+++ b/lib/facter/ipmi.rb
@@ -75,8 +75,8 @@ class IPMIChannel
   end
 end
 
-channel_array = (1..11).to_a
-channel_array.each do |channel|
+channels = (1..11).to_a
+channels.each do |channel|
   @channel_nr = channel
   IPMIChannel.new(@channel_nr).load_facts
 end
@@ -84,33 +84,33 @@ end
 Facter.add(:ipmi) do
   confine kernel: 'Linux'
   setcode do
-    ipmi_hash = {}
+    ipmi = {}
     if Facter::Util::Resolution.which('ipmitool')
       (1..11).each do |channel_nr|
-        lan_channel_hash = {}
+        lan_channel = {}
         ipmitool_output = Facter::Util::Resolution.exec("ipmitool lan print #{channel_nr} 2>&1")
         ipmitool_output.each_line do |line|
           case line.strip
           when %r{^IP Address\s*:\s+(\S.*)}
-            lan_channel_hash['ipaddress'] = Regexp.last_match(1)
+            lan_channel['ipaddress'] = Regexp.last_match(1)
           when %r{^IP Address Source\s*:\s+(\S.*)}
-            lan_channel_hash['ipaddress_source'] = Regexp.last_match(1)
+            lan_channel['ipaddress_source'] = Regexp.last_match(1)
           when %r{^Subnet Mask\s*:\s+(\S.*)}
-            lan_channel_hash['subnet_mask'] = Regexp.last_match(1)
+            lan_channel['subnet_mask'] = Regexp.last_match(1)
           when %r{^MAC Address\s*:\s+(\S.*)}
-            lan_channel_hash['macaddress'] = Regexp.last_match(1)
+            lan_channel['macaddress'] = Regexp.last_match(1)
           when %r{^Default Gateway IP\s*:\s+(\S.*)}
-            lan_channel_hash['gateway'] = Regexp.last_match(1)
+            lan_channel['gateway'] = Regexp.last_match(1)
           end
         end
 
-        next if lan_channel_hash.empty?
+        next if lan_channel.empty?
 
-        lan_channel_hash['channel'] = channel_nr
-        ipmi_hash['default'] = lan_channel_hash unless ipmi_hash.key?('default')
-        ipmi_hash[channel_nr] = lan_channel_hash
+        lan_channel['channel'] = channel_nr
+        ipmi['default'] = lan_channel unless ipmi.key?('default')
+        ipmi[channel_nr] = lan_channel
       end
     end
-    ipmi_hash
+    ipmi
   end
 end

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -17,7 +17,7 @@ define ipmi::network (
   Stdlib::IP::Address $netmask = '255.255.255.0',
   Stdlib::IP::Address $gateway = '0.0.0.0',
   Enum['dhcp', 'static'] $type = 'dhcp',
-  Integer $lan_channel         = $facts['ipmi_lan_channel'],
+  Integer $lan_channel         = $facts['ipmi']['default']['channel'],
 ) {
   require ipmi::install
 

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -10,13 +10,14 @@
 #   Controls the if IP will be from DHCP or Static.
 # @param lan_channel
 #   Controls the lan channel of the IPMI network to be configured.
+#   Defaults to the first detected lan channel, starting at 1 ending at 11
 #
 define ipmi::network (
   Stdlib::IP::Address $ip      = '0.0.0.0',
   Stdlib::IP::Address $netmask = '255.255.255.0',
   Stdlib::IP::Address $gateway = '0.0.0.0',
   Enum['dhcp', 'static'] $type = 'dhcp',
-  Integer $lan_channel         = 1,
+  Integer $lan_channel         = $facts['ipmi_lan_channel'],
 ) {
   require ipmi::install
 

--- a/manifests/snmp.pp
+++ b/manifests/snmp.pp
@@ -5,10 +5,11 @@
 #   Controls the snmp string of the IPMI network interface.
 # @param lan_channel
 #   Controls the lan channel of the IPMI network on which snmp is to be configured.
+#   Defaults to the first detected lan channel, starting at 1 ending at 11
 #
 define ipmi::snmp (
   String $snmp         = 'public',
-  Integer $lan_channel = 1,
+  Integer $lan_channel = $facts['ipmi_lan_channel'],
 ) {
   require ipmi::install
 

--- a/manifests/snmp.pp
+++ b/manifests/snmp.pp
@@ -9,7 +9,7 @@
 #
 define ipmi::snmp (
   String $snmp         = 'public',
-  Integer $lan_channel = $facts['ipmi_lan_channel'],
+  Integer $lan_channel = $facts['ipmi']['default']['channel'],
 ) {
   require ipmi::install
 

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -29,7 +29,7 @@ define ipmi::user (
   Boolean $enable  = true,
   Integer $user_id = 3,
   Optional[Variant[Sensitive[String[1]], String[1]]] $password = undef,
-  Integer $channel = $facts['ipmi_channel'],
+  Integer $channel = $facts['ipmi']['default']['channel'],
 ) {
   require ipmi::install
 

--- a/spec/classes/ipmi_spec.rb
+++ b/spec/classes/ipmi_spec.rb
@@ -24,12 +24,14 @@ end
 describe 'ipmi', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts.merge(
-        {
-          :ipmitool_mc_info => { :IPMI_Puppet_Service_Recommend => 'running' },
-          :ipmi => { :default => { :channel => 1}}
-        }
-      ) }
+      let(:facts) do
+        facts.merge(
+          {
+            ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
+            ipmi: { default: { channel: 1 } }
+          }
+        )
+      end
 
       case facts[:os]['family']
       when 'RedHat'

--- a/spec/classes/ipmi_spec.rb
+++ b/spec/classes/ipmi_spec.rb
@@ -24,7 +24,12 @@ end
 describe 'ipmi', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts.merge(ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' }) }
+      let(:facts) { facts.merge(
+        {
+          :ipmitool_mc_info => { :IPMI_Puppet_Service_Recommend => 'running' },
+          :ipmi => { :default => { :channel => 1}}
+        }
+      ) }
 
       case facts[:os]['family']
       when 'RedHat'

--- a/spec/defines/ipmi_network_spec.rb
+++ b/spec/defines/ipmi_network_spec.rb
@@ -5,7 +5,12 @@ require 'spec_helper'
 describe 'ipmi::network', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts.merge(ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' }) }
+      let(:facts) let(:facts) { facts.merge(
+        {
+          :ipmitool_mc_info => { :IPMI_Puppet_Service_Recommend => 'running' },
+          :ipmi => { :default => { :channel => 1}}
+        }
+      ) }
       let(:title) { 'example' }
 
       describe 'when deploying as dhcp with minimal params' do

--- a/spec/defines/ipmi_network_spec.rb
+++ b/spec/defines/ipmi_network_spec.rb
@@ -5,12 +5,14 @@ require 'spec_helper'
 describe 'ipmi::network', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) let(:facts) { facts.merge(
-        {
-          :ipmitool_mc_info => { :IPMI_Puppet_Service_Recommend => 'running' },
-          :ipmi => { :default => { :channel => 1}}
-        }
-      ) }
+      let(:facts) do
+        facts.merge(
+          {
+            ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
+            ipmi: { default: { channel: 1 } }
+          }
+        )
+      end
       let(:title) { 'example' }
 
       describe 'when deploying as dhcp with minimal params' do

--- a/spec/defines/ipmi_snmp_spec.rb
+++ b/spec/defines/ipmi_snmp_spec.rb
@@ -14,6 +14,7 @@ describe 'ipmi::snmp', type: :define do
 
       },
       ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
+      ipmi: { default:{ channel: 1}},
     }
   end
 

--- a/spec/defines/ipmi_snmp_spec.rb
+++ b/spec/defines/ipmi_snmp_spec.rb
@@ -14,7 +14,7 @@ describe 'ipmi::snmp', type: :define do
 
       },
       ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
-      ipmi: { default:{ channel: 1}},
+      ipmi: { default: { channel: 1 } },
     }
   end
 

--- a/spec/defines/ipmi_user_spec.rb
+++ b/spec/defines/ipmi_user_spec.rb
@@ -5,7 +5,12 @@ require 'spec_helper'
 describe 'ipmi::user', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts.merge(ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' }) }
+      let(:facts) { facts.merge(
+        {
+          :ipmitool_mc_info => { :IPMI_Puppet_Service_Recommend => 'running' },
+          :ipmi => { :default => { :channel => 1}}
+        }
+      ) }
       let(:title) { 'newuser' }
 
       context 'when deploying with password param' do

--- a/spec/defines/ipmi_user_spec.rb
+++ b/spec/defines/ipmi_user_spec.rb
@@ -5,12 +5,14 @@ require 'spec_helper'
 describe 'ipmi::user', type: :define do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts.merge(
-        {
-          :ipmitool_mc_info => { :IPMI_Puppet_Service_Recommend => 'running' },
-          :ipmi => { :default => { :channel => 1}}
-        }
-      ) }
+      let(:facts) do
+        facts.merge(
+          {
+            ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
+            ipmi: { default: { channel: 1 } }
+          }
+        )
+      end
       let(:title) { 'newuser' }
 
       context 'when deploying with password param' do

--- a/spec/unit/facter/ipmi_spec.rb
+++ b/spec/unit/facter/ipmi_spec.rb
@@ -52,32 +52,32 @@ describe 'ipmi facts' do
 
         it do
           expect(Facter.value(:ipmi_ipaddress)).to eq('192.168.0.37')
-          expect(Facter.value(:ipmi)['default']['ipaddress']).to eq('192.168.0.37')
-          expect(Facter.value(:ipmi)[1]['ipaddress']).to eq('192.168.0.37')
+          expect(Facter.value('ipmi.default.ipaddress')).to eq('192.168.0.37')
+          expect(Facter.value('ipmi.1.ipaddress')).to eq('192.168.0.37')
         end
 
         it do
           expect(Facter.value(:ipmi_ipaddress_source)).to eq('DHCP Address')
-          expect(Facter.value(:ipmi)['default']['ipaddress_source']).to eq('DHCP Address')
-          expect(Facter.value(:ipmi)[1]['ipaddress_source']).to eq('DHCP Address')
+          expect(Facter.value('ipmi.default.ipaddress_source')).to eq('DHCP Address')
+          expect(Facter.value('ipmi.1.ipaddress_source')).to eq('DHCP Address')
         end
 
         it do
           expect(Facter.value(:ipmi_subnet_mask)).to eq('255.255.255.0')
-          expect(Facter.value(:ipmi)['default']['subnet_mask']).to eq('255.255.255.0')
-          expect(Facter.value(:ipmi)[1]['subnet_mask']).to eq('255.255.255.0')
+          expect(Facter.value('ipmi.default.subnet_mask')).to eq('255.255.255.0')
+          expect(Facter.value('ipmi.1.subnet_mask')).to eq('255.255.255.0')
         end
 
         it do
           expect(Facter.value(:ipmi_macaddress)).to eq('3c:a8:2a:9f:9a:92')
-          expect(Facter.value(:ipmi)['default']['macaddress']).to eq('3c:a8:2a:9f:9a:92')
-          expect(Facter.value(:ipmi)[1]['macaddress']).to eq('3c:a8:2a:9f:9a:92')
+          expect(Facter.value('ipmi.default.macaddress')).to eq('3c:a8:2a:9f:9a:92')
+          expect(Facter.value('ipmi.1.macaddress')).to eq('3c:a8:2a:9f:9a:92')
         end
 
         it do
           expect(Facter.value(:ipmi_gateway)).to eq('192.168.0.1')
-          expect(Facter.value(:ipmi)['default']['gateway']).to eq('192.168.0.1')
-          expect(Facter.value(:ipmi)[1]['gateway']).to eq('192.168.0.1')
+          expect(Facter.value('ipmi.default.gateway')).to eq('192.168.0.1')
+          expect(Facter.value('ipmi.1.gateway')).to eq('192.168.0.1')
         end
       end
 
@@ -154,64 +154,59 @@ describe 'ipmi facts' do
         describe 'ipmi2_* facts' do
           it do
             expect(Facter.value(:ipmi2_gateway)).to eq('192.168.0.2')
-            expect(Facter.value(:ipmi)['default']['gateway']).to eq('192.168.0.2')
-            expect(Facter.value(:ipmi)[2]['gateway']).to eq('192.168.0.2')
+            expect(Facter.value('ipmi.default.gateway')).to eq('192.168.0.2')
+            expect(Facter.value('ipmi.2.gateway')).to eq('192.168.0.2')
           end
 
           it do
             expect(Facter.value(:ipmi2_ipaddress)).to eq('192.168.0.22')
-            expect(Facter.value(:ipmi)['default']['ipaddress']).to eq('192.168.0.22')
-            expect(Facter.value(:ipmi)[2]['ipaddress']).to eq('192.168.0.22')
+            expect(Facter.value('ipmi.default.ipaddress')).to eq('192.168.0.22')
+            expect(Facter.value('ipmi.2.ipaddress')).to eq('192.168.0.22')
           end
 
           it do
             expect(Facter.value(:ipmi2_ipaddress_source)).to eq('DHCP Address')
-            expect(Facter.value(:ipmi)['default']['ipaddress_source']).to eq('DHCP Address')
-            expect(Facter.value(:ipmi)[2]['ipaddress_source']).to eq('DHCP Address')
+            expect(Facter.value('ipmi.default.ipaddress_source')).to eq('DHCP Address')
+            expect(Facter.value('ipmi.2.ipaddress_source')).to eq('DHCP Address')
           end
 
           it do
             expect(Facter.value(:ipmi2_subnet_mask)).to eq('255.255.255.0')
-            expect(Facter.value(:ipmi)['default']['subnet_mask']).to eq('255.255.255.0')
-            expect(Facter.value(:ipmi)[2]['subnet_mask']).to eq('255.255.255.0')
+            expect(Facter.value('ipmi.default.subnet_mask')).to eq('255.255.255.0')
+            expect(Facter.value('ipmi.2.subnet_mask')).to eq('255.255.255.0')
           end
 
           it do
             expect(Facter.value(:ipmi2_macaddress)).to eq('c6:92:00:22:79:f3')
-            expect(Facter.value(:ipmi)['default']['macaddress']).to eq('c6:92:00:22:79:f3')
-            expect(Facter.value(:ipmi)[2]['macaddress']).to eq('c6:92:00:22:79:f3')
+            expect(Facter.value('ipmi.default.macaddress')).to eq('c6:92:00:22:79:f3')
+            expect(Facter.value('ipmi.2.macaddress')).to eq('c6:92:00:22:79:f3')
           end
         end
 
         describe 'ipmi3_* facts' do
           it do
             expect(Facter.value(:ipmi3_gateway)).to eq('192.168.0.3')
-            expect(Facter.value(:ipmi)['default']['gateway']).to eq('192.168.0.3')
-            expect(Facter.value(:ipmi)[3]['gateway']).to eq('192.168.0.3')
+            expect(Facter.value('ipmi.3.gateway')).to eq('192.168.0.3')
           end
 
           it do
             expect(Facter.value(:ipmi3_ipaddress)).to eq('192.168.0.33')
-            expect(Facter.value(:ipmi)['default']['ipaddress']).to eq('192.168.0.33')
-            expect(Facter.value(:ipmi)[3]['ipaddress']).to eq('192.168.0.33')
+            expect(Facter.value('ipmi.3.ipaddress')).to eq('192.168.0.33')
           end
 
           it do
             expect(Facter.value(:ipmi3_ipaddress_source)).to eq('DHCP Address')
-            expect(Facter.value(:ipmi)['default']['ipaddress_source']).to eq('DHCP Address')
-            expect(Facter.value(:ipmi)[3]['ipaddress_source']).to eq('DHCP Address')
+            expect(Facter.value('ipmi.3.ipaddress_source')).to eq('DHCP Address')
           end
 
           it do
             expect(Facter.value(:ipmi3_subnet_mask)).to eq('255.255.255.0')
-            expect(Facter.value(:ipmi)['default']['subnet_mask']).to eq('255.255.255.0')
-            expect(Facter.value(:ipmi)[3]['subnet_mask']).to eq('255.255.255.0')
+            expect(Facter.value('ipmi.3.subnet_mask')).to eq('255.255.255.0')
           end
 
           it do
             expect(Facter.value(:ipmi3_macaddress)).to eq('1a:16:97:fb:64:d8')
-            expect(Facter.value(:ipmi)['default']['macaddress']).to eq('1a:16:97:fb:64:d8')
-            expect(Facter.value(:ipmi)[3]['macaddress']).to eq('1a:16:97:fb:64:d8')
+            expect(Facter.value('ipmi.3.macaddress')).to eq('1a:16:97:fb:64:d8')
           end
         end
       end

--- a/spec/unit/facter/ipmi_spec.rb
+++ b/spec/unit/facter/ipmi_spec.rb
@@ -52,22 +52,32 @@ describe 'ipmi facts' do
 
         it do
           expect(Facter.value(:ipmi_ipaddress)).to eq('192.168.0.37')
+          expect(Facter.value(:ipmi)['default']['ipaddress']).to eq('192.168.0.37')
+          expect(Facter.value(:ipmi)[1]['ipaddress']).to eq('192.168.0.37')
         end
 
         it do
           expect(Facter.value(:ipmi_ipaddress_source)).to eq('DHCP Address')
+          expect(Facter.value(:ipmi)['default']['ipaddress_source']).to eq('DHCP Address')
+          expect(Facter.value(:ipmi)[1]['ipaddress_source']).to eq('DHCP Address')
         end
 
         it do
           expect(Facter.value(:ipmi_subnet_mask)).to eq('255.255.255.0')
+          expect(Facter.value(:ipmi)['default']['subnet_mask']).to eq('255.255.255.0')
+          expect(Facter.value(:ipmi)[1]['subnet_mask']).to eq('255.255.255.0')
         end
 
         it do
           expect(Facter.value(:ipmi_macaddress)).to eq('3c:a8:2a:9f:9a:92')
+          expect(Facter.value(:ipmi)['default']['macaddress']).to eq('3c:a8:2a:9f:9a:92')
+          expect(Facter.value(:ipmi)[1]['macaddress']).to eq('3c:a8:2a:9f:9a:92')
         end
 
         it do
           expect(Facter.value(:ipmi_gateway)).to eq('192.168.0.1')
+          expect(Facter.value(:ipmi)['default']['gateway']).to eq('192.168.0.1')
+          expect(Facter.value(:ipmi)[1]['gateway']).to eq('192.168.0.1')
         end
       end
 
@@ -144,44 +154,64 @@ describe 'ipmi facts' do
         describe 'ipmi2_* facts' do
           it do
             expect(Facter.value(:ipmi2_gateway)).to eq('192.168.0.2')
+            expect(Facter.value(:ipmi)['default']['gateway']).to eq('192.168.0.2')
+            expect(Facter.value(:ipmi)[2]['gateway']).to eq('192.168.0.2')
           end
 
           it do
             expect(Facter.value(:ipmi2_ipaddress)).to eq('192.168.0.22')
+            expect(Facter.value(:ipmi)['default']['ipaddress']).to eq('192.168.0.22')
+            expect(Facter.value(:ipmi)[2]['ipaddress']).to eq('192.168.0.22')
           end
 
           it do
             expect(Facter.value(:ipmi2_ipaddress_source)).to eq('DHCP Address')
+            expect(Facter.value(:ipmi)['default']['ipaddress_source']).to eq('DHCP Address')
+            expect(Facter.value(:ipmi)[2]['ipaddress_source']).to eq('DHCP Address')
           end
 
           it do
             expect(Facter.value(:ipmi2_subnet_mask)).to eq('255.255.255.0')
+            expect(Facter.value(:ipmi)['default']['subnet_mask']).to eq('255.255.255.0')
+            expect(Facter.value(:ipmi)[2]['subnet_mask']).to eq('255.255.255.0')
           end
 
           it do
             expect(Facter.value(:ipmi2_macaddress)).to eq('c6:92:00:22:79:f3')
+            expect(Facter.value(:ipmi)['default']['macaddress']).to eq('c6:92:00:22:79:f3')
+            expect(Facter.value(:ipmi)[2]['macaddress']).to eq('c6:92:00:22:79:f3')
           end
         end
 
         describe 'ipmi3_* facts' do
           it do
             expect(Facter.value(:ipmi3_gateway)).to eq('192.168.0.3')
+            expect(Facter.value(:ipmi)['default']['gateway']).to eq('192.168.0.3')
+            expect(Facter.value(:ipmi)[3]['gateway']).to eq('192.168.0.3')
           end
 
           it do
             expect(Facter.value(:ipmi3_ipaddress)).to eq('192.168.0.33')
+            expect(Facter.value(:ipmi)['default']['ipaddress']).to eq('192.168.0.33')
+            expect(Facter.value(:ipmi)[3]['ipaddress']).to eq('192.168.0.33')
           end
 
           it do
             expect(Facter.value(:ipmi3_ipaddress_source)).to eq('DHCP Address')
+            expect(Facter.value(:ipmi)['default']['ipaddress_source']).to eq('DHCP Address')
+            expect(Facter.value(:ipmi)[3]['ipaddress_source']).to eq('DHCP Address')
           end
 
           it do
             expect(Facter.value(:ipmi3_subnet_mask)).to eq('255.255.255.0')
+            expect(Facter.value(:ipmi)['default']['subnet_mask']).to eq('255.255.255.0')
+            expect(Facter.value(:ipmi)[3]['subnet_mask']).to eq('255.255.255.0')
           end
 
           it do
             expect(Facter.value(:ipmi3_macaddress)).to eq('1a:16:97:fb:64:d8')
+            expect(Facter.value(:ipmi)['default']['macaddress']).to eq('1a:16:97:fb:64:d8')
+            expect(Facter.value(:ipmi)[3]['macaddress']).to eq('1a:16:97:fb:64:d8')
           end
         end
       end
@@ -196,6 +226,7 @@ describe 'ipmi facts' do
     it do
       Facter::Util::Resolution.expects(:which).at_least(1).with('ipmitool').returns(false)
       expect(Facter.value(:ipmi_ipaddress)).to be_nil
+      expect(Facter.value(:ipmi)).to be_empty
     end
   end
 end


### PR DESCRIPTION
Based on https://github.com/jhoblitt/puppet-ipmi/pull/32 .

Intentionally named ::user parameter `channel` instead of `lan_channel` to be more general.