### PR TITLE
add ipmi::default_channel param to fix chicken and egg failure

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,5 @@
 ---
 fixtures:
   forge_modules:
-    stdlib:
-      repo: "puppetlabs/stdlib"
-      ref: "8.6.0"
+    stdlib: "puppetlabs/stdlib"
     augeas_core: "puppetlabs/augeas_core"

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -43,6 +43,7 @@ The following parameters are available in the `ipmi` class:
 * [`snmps`](#-ipmi--snmps)
 * [`users`](#-ipmi--users)
 * [`networks`](#-ipmi--networks)
+* [`default_channel`](#-ipmi--default_channel)
 
 ##### <a name="-ipmi--packages"></a>`packages`
 
@@ -104,6 +105,14 @@ Data type: `Optional[Hash]`
 
 `ipmi::network` resources to create.
 
+##### <a name="-ipmi--default_channel"></a>`default_channel`
+
+Data type: `Integer[0]`
+
+Default channel to use for IPMI commands.
+
+Default value: `Integer(fact('ipmi.default.channel') or 1)`
+
 ## Defined types
 
 ### <a name="ipmi--network"></a>`ipmi::network`
@@ -154,12 +163,12 @@ Default value: `'dhcp'`
 
 ##### <a name="-ipmi--network--lan_channel"></a>`lan_channel`
 
-Data type: `Integer`
+Data type: `Optional[Integer]`
 
 Controls the lan channel of the IPMI network to be configured.
 Defaults to the first detected lan channel, starting at 1 ending at 11
 
-Default value: `$facts['ipmi']['default']['channel']`
+Default value: `undef`
 
 ### <a name="ipmi--snmp"></a>`ipmi::snmp`
 
@@ -182,12 +191,12 @@ Default value: `'public'`
 
 ##### <a name="-ipmi--snmp--lan_channel"></a>`lan_channel`
 
-Data type: `Integer`
+Data type: `Optional[Integer]`
 
 Controls the lan channel of the IPMI network on which snmp is to be configured.
 Defaults to the first detected lan channel, starting at 1 ending at 11
 
-Default value: `$facts['ipmi']['default']['channel']`
+Default value: `undef`
 
 ### <a name="ipmi--user"></a>`ipmi::user`
 
@@ -254,10 +263,10 @@ Default value: `undef`
 
 ##### <a name="-ipmi--user--channel"></a>`channel`
 
-Data type: `Integer`
+Data type: `Optional[Integer]`
 
 Controls the channel of the IPMI user to be configured.
 Defaults to the first detected lan channel, starting at 1 ending at 11
 
-Default value: `$facts['ipmi']['default']['channel']`
+Default value: `undef`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,8 @@
 #   `ipmi::user` resources to create.
 # @param networks
 #   `ipmi::network` resources to create.
+# @param default_channel
+#   Default channel to use for IPMI commands.
 #
 class ipmi (
   Array[String] $packages,
@@ -33,6 +35,7 @@ class ipmi (
   Optional[Hash] $snmps,
   Optional[Hash] $users,
   Optional[Hash] $networks,
+  Integer[0] $default_channel = Integer(fact('ipmi.default.channel') or 1),
 ) {
   $enable_ipmi = $service_ensure ? {
     'running' => true,

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -13,47 +13,52 @@
 #   Defaults to the first detected lan channel, starting at 1 ending at 11
 #
 define ipmi::network (
-  Stdlib::IP::Address $ip      = '0.0.0.0',
-  Stdlib::IP::Address $netmask = '255.255.255.0',
-  Stdlib::IP::Address $gateway = '0.0.0.0',
-  Enum['dhcp', 'static'] $type = 'dhcp',
-  Integer $lan_channel         = $facts['ipmi']['default']['channel'],
+  Stdlib::IP::Address $ip        = '0.0.0.0',
+  Stdlib::IP::Address $netmask   = '255.255.255.0',
+  Stdlib::IP::Address $gateway   = '0.0.0.0',
+  Enum['dhcp', 'static'] $type   = 'dhcp',
+  Optional[Integer] $lan_channel = undef
 ) {
   require ipmi::install
 
+  $_real_lan_channel = $lan_channel ? {
+    undef => $ipmi::default_channel,
+    default => $lan_channel,
+  }
+
   if $type == 'dhcp' {
-    exec { "ipmi_set_dhcp_${lan_channel}":
-      command => "/usr/bin/ipmitool lan set ${lan_channel} ipsrc dhcp",
-      onlyif  => "/usr/bin/test $(ipmitool lan print ${lan_channel} | grep 'IP \
+    exec { "ipmi_set_dhcp_${_real_lan_channel}":
+      command => "/usr/bin/ipmitool lan set ${_real_lan_channel} ipsrc dhcp",
+      onlyif  => "/usr/bin/test $(ipmitool lan print ${_real_lan_channel} | grep 'IP \
 Address Source' | cut -f 2 -d : | grep -c DHCP) -eq 0",
     }
   } else {
-    exec { "ipmi_set_static_${lan_channel}":
-      command => "/usr/bin/ipmitool lan set ${lan_channel} ipsrc static",
-      onlyif  => "/usr/bin/test $(ipmitool lan print ${lan_channel} | grep 'IP \
+    exec { "ipmi_set_static_${_real_lan_channel}":
+      command => "/usr/bin/ipmitool lan set ${_real_lan_channel} ipsrc static",
+      onlyif  => "/usr/bin/test $(ipmitool lan print ${_real_lan_channel} | grep 'IP \
 Address Source' | cut -f 2 -d : | grep -c DHCP) -eq 1",
       notify  => [
-        Exec["ipmi_set_ipaddr_${lan_channel}"],
-        Exec["ipmi_set_defgw_${lan_channel}"],
-        Exec["ipmi_set_netmask_${lan_channel}"],
+        Exec["ipmi_set_ipaddr_${_real_lan_channel}"],
+        Exec["ipmi_set_defgw_${_real_lan_channel}"],
+        Exec["ipmi_set_netmask_${_real_lan_channel}"],
       ],
     }
 
-    exec { "ipmi_set_ipaddr_${lan_channel}":
-      command => "/usr/bin/ipmitool lan set ${lan_channel} ipaddr ${ip}",
-      onlyif  => "/usr/bin/test \"$(ipmitool lan print ${lan_channel} | grep \
+    exec { "ipmi_set_ipaddr_${_real_lan_channel}":
+      command => "/usr/bin/ipmitool lan set ${_real_lan_channel} ipaddr ${ip}",
+      onlyif  => "/usr/bin/test \"$(ipmitool lan print ${_real_lan_channel} | grep \
 'IP Address  ' | sed -e 's/.* : //g')\" != \"${ip}\"",
     }
 
-    exec { "ipmi_set_defgw_${lan_channel}":
-      command => "/usr/bin/ipmitool lan set ${lan_channel} defgw ipaddr ${gateway}",
-      onlyif  => "/usr/bin/test \"$(ipmitool lan print ${lan_channel} | grep \
+    exec { "ipmi_set_defgw_${_real_lan_channel}":
+      command => "/usr/bin/ipmitool lan set ${_real_lan_channel} defgw ipaddr ${gateway}",
+      onlyif  => "/usr/bin/test \"$(ipmitool lan print ${_real_lan_channel} | grep \
 'Default Gateway IP' | sed -e 's/.* : //g')\" != \"${gateway}\"",
     }
 
-    exec { "ipmi_set_netmask_${lan_channel}":
-      command => "/usr/bin/ipmitool lan set ${lan_channel} netmask ${netmask}",
-      onlyif  => "/usr/bin/test \"$(ipmitool lan print ${lan_channel} | grep \
+    exec { "ipmi_set_netmask_${_real_lan_channel}":
+      command => "/usr/bin/ipmitool lan set ${_real_lan_channel} netmask ${netmask}",
+      onlyif  => "/usr/bin/test \"$(ipmitool lan print ${_real_lan_channel} | grep \
 'Subnet Mask' | sed -e 's/.* : //g')\" != \"${netmask}\"",
     }
   }

--- a/manifests/snmp.pp
+++ b/manifests/snmp.pp
@@ -8,13 +8,18 @@
 #   Defaults to the first detected lan channel, starting at 1 ending at 11
 #
 define ipmi::snmp (
-  String $snmp         = 'public',
-  Integer $lan_channel = $facts['ipmi']['default']['channel'],
+  String $snmp                   = 'public',
+  Optional[Integer] $lan_channel = undef,
 ) {
   require ipmi::install
 
-  exec { "ipmi_set_snmp_${lan_channel}":
-    command => "/usr/bin/ipmitool lan set ${lan_channel} snmp ${snmp}",
-    onlyif  => "/usr/bin/test \"$(ipmitool lan print ${lan_channel} | grep 'SNMP Community String' | sed -e 's/.* : //g')\" != \"${snmp}\"",
+  $_real_lan_channel = $lan_channel ? {
+    undef => $ipmi::default_channel,
+    default => $lan_channel,
+  }
+
+  exec { "ipmi_set_snmp_${_real_lan_channel}":
+    command => "/usr/bin/ipmitool lan set ${_real_lan_channel} snmp ${snmp}",
+    onlyif  => "/usr/bin/test \"$(ipmitool lan print ${_real_lan_channel} | grep 'SNMP Community String' | sed -e 's/.* : //g')\" != \"${snmp}\"",
   }
 }


### PR DESCRIPTION
On a host which does not have ipmitool installed (or working), `ipmi.default` is undefined and looking up `ipmi.default.channel` fails. This is a race condition that prevents puppet from being able to install ipmitool to make the fact functional on a subsequent agent run.

Resolves #88 