### PR TITLE
Ensure _real_channel replaces all channel instances

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -65,13 +65,13 @@ define ipmi::user (
 
     exec { "ipmi_user_add_${title}":
       command => "/usr/bin/ipmitool user set name ${user_id} ${user}",
-      unless  => "/usr/bin/ipmitool user list ${channel} | grep -qE '^${user_id}[ ]+${user} '",
+      unless  => "/usr/bin/ipmitool user list ${_real_channel} | grep -qE '^${user_id}[ ]+${user} '",
       notify  => [Exec["ipmi_user_priv_${title}"], Exec["ipmi_user_setpw_${title}"]],
     }
 
     exec { "ipmi_user_priv_${title}":
-      command => "/usr/bin/ipmitool user priv ${user_id} ${priv} ${channel}",
-      unless  => "/usr/bin/ipmitool user list ${channel} | grep -qE '^${user_id} .+ ${privilege}$'",
+      command => "/usr/bin/ipmitool user priv ${user_id} ${priv} ${_real_channel}",
+      unless  => "/usr/bin/ipmitool user list ${_real_channel} | grep -qE '^${user_id} .+ ${privilege}$'",
       notify  => [Exec["ipmi_user_enable_${title}"], Exec["ipmi_user_enable_sol_${title}"], Exec["ipmi_user_channel_setaccess_${title}"]],
     }
 


### PR DESCRIPTION
These instances of `channel` were missed when `_real_channel` was created.