### PR TITLE
Clear disabled usernames on Dell servers

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,5 +6,5 @@ class ipmi::install {
 
   include ipmi
 
-  ensure_packages($ipmi::packages)
+  stdlib::ensure_packages($ipmi::packages)
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -131,5 +131,18 @@ define ipmi::user (
       command     => "/usr/bin/ipmitool channel setaccess ${_real_channel} ${user_id} callin=off ipmi=off link=off privilege=15",
       refreshonly => true,
     }
+
+    if downcase($facts['ipmitool']['mc_info']['Manufacturer Name']) =~ /dell/ {
+      # this looks weird, but ${facts['ipmi']['default']['users'][$user_id] expects
+      # $user_id to be a string wrapped in quotes (check the ipmi fact). Separating it
+      # out here works around shell quoting issues, and quoting lint checks
+      $user_id_str = String($user_id)
+      exec { "ipmi_dell_clear_username_${title}":
+        command   => "/usr/bin/ipmitool user set name ${user_id} ''",
+        # test this by using -z instead of -n to verify the code is "not not" working
+        onlyif    => "/bin/test -n '${facts['ipmi']['default']['users'][$user_id_str]['name']}'",
+        subscribe => Exec["ipmi_user_priv_${title}"],
+      }
+    }
   }
 }

--- a/spec/defines/ipmi_user_spec.rb
+++ b/spec/defines/ipmi_user_spec.rb
@@ -9,6 +9,7 @@ describe 'ipmi::user', type: :define do
         facts.merge(
           {
             ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
+            ipmitool: { mc_info: { 'Manufacturer Name' => 'Generic' } },
             ipmi: { default: { channel: 1 } }
           }
         )
@@ -146,7 +147,50 @@ describe 'ipmi::user', type: :define do
 
         it { is_expected.not_to contain_exec('ipmi_user_enable_newuser') }
         it { is_expected.not_to contain_exec('ipmi_user_enable_sol_newuser') }
+
       end
+    end
+  end
+  
+  # Test Dell-specific functionality separately
+  describe 'ipmi::user Dell functionality', type: :define do
+    let(:title) { 'newuser' }
+    let(:params) { { enable: false } }
+    
+    context 'with Dell hardware' do
+      let(:facts) do
+        {
+          ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
+          ipmitool: { 
+            mc_info: { 
+              'Manufacturer Name' => 'Dell Inc.'
+            }
+          },
+          ipmi: { default: { channel: 1, users: { '3' => { 'name' => 'newuser' }}}}
+        }
+      end
+      
+      it { is_expected.to contain_exec('ipmi_dell_clear_username_newuser').with(
+        'command' => '/usr/bin/ipmitool user set name 3 \'\'',
+        'onlyif' => "/bin/test -n 'newuser'",
+        'subscribe' => 'Exec[ipmi_user_priv_newuser]'
+      )}
+    end
+    
+    context 'with non-Dell hardware' do
+      let(:facts) do
+        {
+          ipmitool_mc_info: { IPMI_Puppet_Service_Recommend: 'running' },
+          ipmitool: { 
+            mc_info: { 
+              'Manufacturer Name' => 'SuperMicro'
+            }
+          },
+          ipmi: { default: { channel: 1 }}
+        }
+      end
+      
+      it { is_expected.not_to contain_exec('ipmi_dell_clear_username_newuser') }
     end
   end
 end


### PR DESCRIPTION
Hi @jhoblitt 

Thanks for this module - it has come in handy

Please find in this PR the ability to also clear a username from the user table on Dell servers, because Dell's support it

I have also tweaked a deprecation notice for `ensure_packages`