### PR TITLE
Remove on user_id mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ Create a user with user privileges on a specific channel:
   }
 ```
 
+Create a user and remove any instance with the wrong `user_id`:
+```puppet
+  ipmi::user { 'newuser1':
+    user     => 'newuser1',
+    password => 'password1',
+    user_id  => 4,
+    purge_id_mismatch => true,
+  }
+```
+
+
 Configure a static ip on IPMI lan channel 1:
 
 ```puppet

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -212,6 +212,7 @@ The following parameters are available in the `ipmi::user` defined type:
 * [`user_id`](#-ipmi--user--user_id)
 * [`password`](#-ipmi--user--password)
 * [`channel`](#-ipmi--user--channel)
+* [`purge_id_mismatch`](#-ipmi--user--purge_id_mismatch)
 
 ##### <a name="-ipmi--user--user"></a>`user`
 
@@ -269,4 +270,15 @@ Controls the channel of the IPMI user to be configured.
 Defaults to the first detected lan channel, starting at 1 ending at 11
 
 Default value: `undef`
+
+##### <a name="-ipmi--user--purge_id_mismatch"></a>`purge_id_mismatch`
+
+Data type: `Boolean`
+
+When true, any IPMI user slot that holds $user at an ID other than $user_id
+will be blanked and disabled before the desired slot is configured.
+IPMI slots cannot be deleted; clearing the name and disabling access is the
+BMC-standard equivalent. Defaults to false. Only applies when $enable is true.
+
+Default value: `false`
 

--- a/files/puppet_ipmi_purge_id_mismatch
+++ b/files/puppet_ipmi_purge_id_mismatch
@@ -1,0 +1,47 @@
+#!/bin/bash
+# THIS FILE IS MANAGED BY PUPPET
+#
+# Blank any IPMI user slot holding <user> at an ID other than <user_id>.
+# The --onlyif guard uses an anchored regex ('^<id> <name>$') to prevent
+# false positives where <user> is a suffix of another username
+# (e.g. 'admin' matching 'superadmin').
+#
+# Usage:
+#   purge:  puppet_ipmi_purge_id_mismatch <channel> <user> <user_id>
+#   onlyif: puppet_ipmi_purge_id_mismatch --onlyif <channel> <user> <user_id>
+
+set -ue
+
+IPMITOOL=ipmitool
+
+onlyif=0
+if [[ "$1" == "--onlyif" ]]; then
+    onlyif=1
+    shift
+fi
+
+channel=$1
+user=$2
+user_id=$3
+
+if (( onlyif )); then
+    # Exit 0 (run) if the username exists at any ID other than user_id,
+    # and that ID is not already a DISABLED_ slot.
+    exec "$IPMITOOL" user list "$channel" 2>/dev/null \
+        | tail -n +2 \
+        | awk '{print $1, $2}' \
+        | grep -vE "^${user_id} " \
+        | grep -vE "^[0-9]+ DISABLED_" \
+        | grep -qE "^[0-9]+ ${user}$"
+fi
+
+while IFS= read -r line; do
+    id=$(awk '{print $1}' <<< "$line")
+    name=$(awk '{print $2}' <<< "$line")
+    if [[ "$name" == "$user" && "$id" != "$user_id" ]]; then
+        "$IPMITOOL" user set name "$id" "DISABLED_$id"
+        "$IPMITOOL" user disable "$id"
+        "$IPMITOOL" channel setaccess "$channel" "$id" \
+            callin=off ipmi=off link=off privilege=15
+    fi
+done < <("$IPMITOOL" user list "$channel" 2>/dev/null | tail -n +2)

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -22,6 +22,11 @@
 # @param channel
 #   Controls the channel of the IPMI user to be configured.
 #   Defaults to the first detected lan channel, starting at 1 ending at 11
+# @param purge_id_mismatch
+#   When true, any IPMI user slot that holds $user at an ID other than $user_id
+#   will be blanked and disabled before the desired slot is configured.
+#   IPMI slots cannot be deleted; clearing the name and disabling access is the
+#   BMC-standard equivalent. Defaults to false. Only applies when $enable is true.
 #
 define ipmi::user (
   String $user                                                 = 'root',
@@ -30,12 +35,34 @@ define ipmi::user (
   Integer $user_id                                             = 3,
   Optional[Variant[Sensitive[String[1]], String[1]]] $password = undef,
   Optional[Integer] $channel                                   = undef,
+  Boolean $purge_id_mismatch                                   = false,
 ) {
   require ipmi::install
 
   $_real_channel = $channel ? {
     undef => $ipmi::default_channel,
     default => $channel,
+  }
+
+  # Blank any IPMI user slot holding $user at an ID other than $user_id.
+  # Must run before ipmi_user_add_${title} to avoid duplicate-name conflicts on the BMC.
+  # Not applied when $enable is false: disabling operates on $user_id directly
+  # and a mismatch at another slot is harmless in that case.
+  if $purge_id_mismatch and $enable {
+    file { '/usr/libexec/puppet_ipmi_purge_id_mismatch':
+      ensure => 'file',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+      source => 'puppet:///modules/ipmi/puppet_ipmi_purge_id_mismatch',
+    }
+
+    exec { "ipmi_user_purge_mismatch_${title}":
+      command => "/usr/libexec/puppet_ipmi_purge_id_mismatch ${_real_channel} ${user} ${user_id}",
+      onlyif  => "/usr/libexec/puppet_ipmi_purge_id_mismatch --onlyif ${_real_channel} ${user} ${user_id}",
+      before  => Exec["ipmi_user_add_${title}"],
+      require => File['/usr/libexec/puppet_ipmi_purge_id_mismatch'],
+    }
   }
 
   if $enable {

--- a/spec/defines/ipmi_user_spec.rb
+++ b/spec/defines/ipmi_user_spec.rb
@@ -40,6 +40,9 @@ describe 'ipmi::user', type: :define do
 
         it { is_expected.not_to contain_exec('ipmi_user_disable_newuser') }
         it { is_expected.not_to contain_exec('ipmi_user_disable_sol_newuser') }
+
+        # purge_id_mismatch defaults false - exec must not be declared
+        it { is_expected.not_to contain_exec('ipmi_user_purge_mismatch_newuser') }
       end
 
       context 'when deploying with all params' do
@@ -67,6 +70,9 @@ describe 'ipmi::user', type: :define do
 
         it { is_expected.to contain_exec('ipmi_user_enable_sol_newuser').with('refreshonly' => 'true') }
         it { is_expected.to contain_exec('ipmi_user_channel_setaccess_newuser').with('refreshonly' => 'true') }
+
+        # purge_id_mismatch defaults false - exec must not be declared
+        it { is_expected.not_to contain_exec('ipmi_user_purge_mismatch_newuser') }
       end
 
       context 'when deploying with all params and a sensitive password' do
@@ -94,6 +100,9 @@ describe 'ipmi::user', type: :define do
 
         it { is_expected.to contain_exec('ipmi_user_enable_sol_newuser').with('refreshonly' => 'true') }
         it { is_expected.to contain_exec('ipmi_user_channel_setaccess_newuser').with('refreshonly' => 'true') }
+
+        # purge_id_mismatch defaults false - exec must not be declared
+        it { is_expected.not_to contain_exec('ipmi_user_purge_mismatch_newuser') }
       end
 
       describe 'when deploying with no params' do
@@ -146,6 +155,74 @@ describe 'ipmi::user', type: :define do
 
         it { is_expected.not_to contain_exec('ipmi_user_enable_newuser') }
         it { is_expected.not_to contain_exec('ipmi_user_enable_sol_newuser') }
+
+        # purge_id_mismatch only applies when enable => true
+        it { is_expected.not_to contain_exec('ipmi_user_purge_mismatch_newuser') }
+      end
+
+      describe 'when disabling a user with purge_id_mismatch => true' do
+        let(:params) do
+          {
+            enable: false,
+            purge_id_mismatch: true,
+          }
+        end
+
+        # purge_id_mismatch is suppressed when enable => false
+        it { is_expected.not_to contain_exec('ipmi_user_purge_mismatch_newuser') }
+
+        it { is_expected.to contain_exec('ipmi_user_disable_newuser').with('refreshonly' => 'true') }
+        it { is_expected.to contain_exec('ipmi_user_disable_sol_newuser').with('refreshonly' => 'true') }
+        it { is_expected.to contain_exec('ipmi_user_channel_setaccess_newuser').with('refreshonly' => 'true') }
+      end
+
+      describe 'when purge_id_mismatch => true with enable => true' do
+        let(:params) do
+          {
+            user: 'newuser1',
+            password: 'password',
+            priv: 3,
+            user_id: 4,
+            purge_id_mismatch: true,
+          }
+        end
+
+        it { is_expected.to contain_exec('ipmi_user_purge_mismatch_newuser') }
+
+        # purge exec must run before the add exec
+        it { is_expected.to contain_exec('ipmi_user_purge_mismatch_newuser').that_comes_before('Exec[ipmi_user_add_newuser]') }
+
+        # normal enable-path resources must still be present
+        it { is_expected.to contain_exec('ipmi_user_enable_newuser').with('refreshonly' => 'true') }
+        it { is_expected.to contain_exec('ipmi_user_add_newuser').that_notifies('Exec[ipmi_user_priv_newuser]') }
+        it { is_expected.to contain_exec('ipmi_user_add_newuser').that_notifies('Exec[ipmi_user_setpw_newuser]') }
+        it { is_expected.to contain_exec('ipmi_user_priv_newuser').that_notifies('Exec[ipmi_user_enable_newuser]') }
+        it { is_expected.to contain_exec('ipmi_user_priv_newuser').that_notifies('Exec[ipmi_user_enable_sol_newuser]') }
+        it { is_expected.to contain_exec('ipmi_user_priv_newuser').that_notifies('Exec[ipmi_user_channel_setaccess_newuser]') }
+        it { is_expected.to contain_exec('ipmi_user_setpw_newuser').that_notifies('Exec[ipmi_user_enable_newuser]') }
+        it { is_expected.to contain_exec('ipmi_user_setpw_newuser').that_notifies('Exec[ipmi_user_enable_sol_newuser]') }
+        it { is_expected.to contain_exec('ipmi_user_setpw_newuser').that_notifies('Exec[ipmi_user_channel_setaccess_newuser]') }
+        it { is_expected.to contain_exec('ipmi_user_enable_sol_newuser').with('refreshonly' => 'true') }
+        it { is_expected.to contain_exec('ipmi_user_channel_setaccess_newuser').with('refreshonly' => 'true') }
+
+        it { is_expected.not_to contain_exec('ipmi_user_disable_newuser') }
+        it { is_expected.not_to contain_exec('ipmi_user_disable_sol_newuser') }
+      end
+
+      describe 'when purge_id_mismatch => true with a sensitive password' do
+        let(:params) do
+          {
+            user: 'newuser1',
+            password: sensitive('password'),
+            priv: 3,
+            user_id: 4,
+            purge_id_mismatch: true,
+          }
+        end
+
+        it { is_expected.to contain_exec('ipmi_user_purge_mismatch_newuser') }
+        it { is_expected.to contain_exec('ipmi_user_purge_mismatch_newuser').that_comes_before('Exec[ipmi_user_add_newuser]') }
+        it { is_expected.to contain_exec('ipmi_user_enable_newuser').with('refreshonly' => 'true') }
       end
     end
   end


### PR DESCRIPTION
This adds a flag to ipmi::user which will remove a user from the user list if it has the wrong user_id.

Some BMC seem to support having a user in multiple slots. Sometimes this gives the user multiple passwords. Sometimes it just has one of them (first or last seems to be vendor dependent).

Multiple users with the same name seems to be buggy behavior...